### PR TITLE
Correct deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Install and Run
 ```
-$ bundle config set path '.bundle/gems'
+$ bundle config set --local path '.bundle/gems'
 $ bundle install --jobs 4
 $ bundle exec guard -i
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Install and Run instructions to use a two-step Bundler setup: first configure the path with `bundle config set path '.bundle/gems'`, then run `bundle install --jobs 4`, replacing the prior inline `--path` usage. This streamlines setup and aligns with common workflows. The subsequent `bundle exec guard -i` step is unchanged; no functional behavior altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->